### PR TITLE
設定ファイルから管理者用メールアドレスを読み込む仕様に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "@prisma/client": "^3.3.0",
+    "dotenv": "^10.0.0",
     "express": "^4.17.1"
   },
   "devDependencies": {
@@ -40,10 +41,9 @@
     "prepare": "husky install"
   },
   "prisma": {
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "ts-node --require dotenv/config prisma/seed.ts"
   },
   "lint-staged": {
-    "*.{ts,js}": "eslint --cache --fix",
     "*.{ts,js}": "prettier --write"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,6 +709,11 @@ doctrine@3.0.0, doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
+
 dynamic-dedupe@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz#06e44c223f5e4e94d78ef9db23a6515ce2f962a1"


### PR DESCRIPTION
# 変更点
- prisma/seedファイルにて初期化時に注入する管理者用メールアドレスを環境変数から読み出すようにした
- 環境変数をシェルにせってするのではなくdotenvを利用して.envファイルから読み出す
- seedコマンド実行時にはしるスクリプトに --require dotenv/config オプションを追加