### PR TITLE
isAdmin カラムの追加

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
+npx lint-staged --allow-empty

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "seed": "ts-node --require dotenv/config prisma/seed.ts"
   },
   "lint-staged": {
+    "*.{ts,js}": "eslint --cache --fix",
     "*.{ts,js}": "prettier --write"
   }
 }

--- a/prisma/migrations/20211116131025_add_is_admin/migration.sql
+++ b/prisma/migrations/20211116131025_add_is_admin/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `User` ADD COLUMN `isAdmin` BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
     id      Int      @id @default(autoincrement())
     email   String   @unique
     token Token[]
+    isAdmin Boolean @default(false)
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -7,6 +7,7 @@ async function main() {
     await prisma.user.create({
         data: {
             email: adminEmail,
+            isAdmin: true,
         },
     });
     const allUsers = await prisma.user.findMany();


### PR DESCRIPTION
# 変更点
- schema.prismaのuserテーブルに管理ユーザーかのboolを示すカラムを追加した
- コミット時に走るスクリプトからeslintが消えていたため、再追加した
- lint-staged が空コミットの時に弾かれるので--allow-emptyオプションを追記した