### PR TITLE
認証の際、Cookieだけでなくヘッダーにもjwtを返す仕様に変更

### DIFF
--- a/src/controller/login.ts
+++ b/src/controller/login.ts
@@ -25,8 +25,9 @@ export class loginController {
                     res.status(errorStatus).json(data.value);
                 } else {
                     const jwt = data.value.token;
-                    res.status(http.StatusCreated())
+                    res.set("token", jwt)
                         .cookie("token", jwt, { httpOnly: true })
+                        .status(http.StatusCreated())
                         .send();
                 }
             })

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -35,7 +35,11 @@ const loginRouter = (s: Service): Router => {
      *                      description: Access token by jwt
      *                      schema:
      *                          type: string
-     *                          example: token=hogehoge;
+     *                          example: token=hogehoge
+     *                  token:
+     *                      description: フロント側でのユーザー情報取得用jwt
+     *                      schema:
+     *                          type: string
      */
     return router;
 };

--- a/swagger.json
+++ b/swagger.json
@@ -55,7 +55,13 @@
                 "description": "Access token by jwt",
                 "schema": {
                   "type": "string",
-                  "example": "token=hogehoge;"
+                  "example": "token=hogehoge"
+                }
+              },
+              "token": {
+                "description": "フロント側でのユーザー情報取得用jwt",
+                "schema": {
+                  "type": "string"
                 }
               }
             }


### PR DESCRIPTION
# 変更点
- /login エンドポイントにてCookieでjwtを返していたが、加えてヘッダーにも乗せるようにした。
- フロント側でユーザー情報をStateにセットする際に使用する。